### PR TITLE
BTVWAG x BurlingtonJS: Front-end Framework Faceoff - February 2014

### DIFF
--- a/_posts/events/2014-02-12-front-end-framework-face-off.md
+++ b/_posts/events/2014-02-12-front-end-framework-face-off.md
@@ -1,0 +1,40 @@
+---
+layout: post
+when: February 12th, 2014
+where: TBA
+what: presentations
+who: Peter Brown, Alan Peabody, Rob Friesel, Ian Metcalf
+title: JavaScript Front-end Framework Face-off
+byline: written by Brett Chalupa
+category: event
+---
+
+BTVWAG x BurlingtonJS presents the Front-end Framework Face-off. The meetup
+will feature four speakers. Three will be covering the major front-end
+frameworks right now: Ember, Angular and Backbone (+ Marionette); the last
+speaker will be covering front-end JavaScript with no framework.
+
+February 12th is the date.
+
+The location is yet to be announced. We need to gauge the interest of the meetup
+to select a space that accommodates the number attendees. If you are interested,
+please RSVP sooner rather than later.
+
+We are looking for a pizza and juice sponsor for the event, so if you are
+interested please let us know.
+
+The speakers:
+
+* Ember - Peter Brown of Agilion
+* Angular - Rob Friesel of Dealer.com
+* Backbone (+ Marionette) - Alan Peabody of Agilion
+* No framework - Ian Metcalf of Draker
+
+The format:
+
+* 20 minutes per framework - covering the good, the bad and the ugly
+* 30 minutes of Q&A moderated by Brett Chalupa
+
+After the Q&A, let's all hangout downtown over some drinks!
+
+[Register now on Meetup.com.](http://www.meetup.com/VTCode/events/162314252/)


### PR DESCRIPTION
This is my proposition for a February 2014 BTVWAG x BurlingtonJS meetup covering the three major front-end frameworks right now: Ember, Angular and Backbone (+ Marionette).

I thought February 12th would give us enough time to find speakers, a location and plan out the evening. I would also like to get a pizza & juice sponsor for this event, if possible.

I get the feeling that this could have quite the number of attendees, so we probably want to pick a location that will accommodate 40+. Would UVM be good for this or some other venue? Any companies that have a space we could use? I could look into hosting it at 47 Maple St.

The format:
- 20 minutes per framework
- 30 minutes of panel & QA moderated by myself
- Head downtown for drinks!  

TODO:
- [ ] find a location
- [x] find ember speaker - Peter Brown in the left corner
- [x] find angular speaker - Rob Friesel in the right corner
- [x] find backbone speaker - Alan Peabody in the upper corner
- [x] set the date - thinking Wednesday, February 12th
- [x] create the meetup event
- [ ] create BurlingtonJS event for the website
- [ ] find pizza & juice sponsor

Ring ring riiiing :phone: calling: @beerlington @alanpeabody @tristanoneil @patrickberkeley. I know that all four of you have experience with at least one of the frameworks at hand. I think you would all be awesome speakers for the framework you want to fight for. However, there can only be three. And if we know of others in the area who would like to speak, we should consider them as well! If you are interested in speaking, speak up!

Please leave thoughts, feedback, concerns, etc. in this pull request. :)

Only one framework will come out alive. :goberserk:
